### PR TITLE
Use correct output_mask

### DIFF
--- a/prawn_do.c
+++ b/prawn_do.c
@@ -22,7 +22,7 @@
 #define OUTPUT_PIN_BASE 0
 #define OUTPUT_WIDTH 16
 // mask which bits we are using
-uint32_t output_mask = (OUTPUT_WIDTH - 1) << OUTPUT_PIN_BASE;
+uint32_t output_mask = ((1 << OUTPUT_WIDTH) - 1) << OUTPUT_PIN_BASE;
 
 #define MAX_DO_CMDS 60000
 // two DO CMDS per INSTRUCTION


### PR DESCRIPTION
Use correct output_mask to cover all 16 pins instead of the first 4 only.

This allows actually using output pins higher than 0-3.