### PR TITLE
Fix regressions introduced by #9

### DIFF
--- a/prawn_do/prawn_do.c
+++ b/prawn_do/prawn_do.c
@@ -201,7 +201,7 @@ void core1_entry() {
 
 		if(command & BUFFERED){
 			// buffered execution
-			uint32_t hwstart = (command & HWSTART);
+			uint32_t hwstart = !!(command & HWSTART);
 
 			set_status(TRANSITION_TO_RUNNING);
 			if(debug){


### PR DESCRIPTION
Both issues were identified in #21 

Ensures `swr` actually starts the sequence instead of requiring a hardware trigger. Also fixes issue with manual updates after an aborted sequence.